### PR TITLE
Bug Fix: Bucket creation in dry run mode fails for non-default regions

### DIFF
--- a/src/bowser/backends/di.py
+++ b/src/bowser/backends/di.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection, Generator, Iterator, MutableSequence
+from collections.abc import Collection, Generator, MutableSequence
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -21,7 +21,7 @@ _CLOSE: _CLOSE_T = "close"
 @contextmanager
 def provide_BowserBackends(  # noqa: N802
     watch_root: Path, config: BowserConfig, dry_run: bool  # noqa: FBT001
-) -> Iterator[Collection[BowserBackend]]:
+) -> Generator[Collection[BowserBackend], None, None]:
     backends: MutableSequence[BowserBackend] = []
     closeables: MutableSequence[Generator[Any, _CLOSE_T, None]] = []
     for backend_config in config.backends:

--- a/src/bowser/backends/di.py
+++ b/src/bowser/backends/di.py
@@ -61,7 +61,10 @@ def provide_S3Client(  # noqa: N802
         with mock_aws():
             client = boto3.client("s3", **kwargs)  # type: ignore[call-overload]
             for bucket in config.buckets:
-                client.create_bucket(Bucket=bucket.name)
+                location = {"LocationConstraint": config.region}
+                client.create_bucket(
+                    Bucket=bucket.name, CreateBucketConfiguration=location
+                )
             _ = yield client
     else:
         client = boto3.client("s3", **kwargs)  # type: ignore[call-overload]

--- a/src/bowser/backends/di.py
+++ b/src/bowser/backends/di.py
@@ -65,9 +65,9 @@ def provide_S3Client(  # noqa: N802
                 client.create_bucket(
                     Bucket=bucket.name, CreateBucketConfiguration=location
                 )
-            _ = yield client
     else:
         client = boto3.client("s3", **kwargs)  # type: ignore[call-overload]
-        signal = yield client
-        if signal == _CLOSE:
-            client.close()
+
+    signal = yield client
+    if signal == _CLOSE:
+        client.close()

--- a/tests/unit/backends/test_di.py
+++ b/tests/unit/backends/test_di.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from hamcrest import assert_that, contains_inanyorder
+
+from bowser.backends.aws import AwsS3Backend
+from bowser.backends.di import provide_BowserBackends
+from bowser.config.backend.aws import AwsS3BowserBackendConfig, Bucket
+from bowser.config.base import BowserConfig
+
+
+def test_provide_BowserBackends(tmp_path: Path):  # noqa: N802
+    backend_config = [
+        AwsS3BowserBackendConfig(
+            region="eu-west-1",  # exercise a region other than the default
+            access_key_id="testing",
+            secret_access_key="testing",  # nosec B106
+            buckets=[Bucket(name="test-bucket", key="")],
+        )
+    ]
+    config = BowserConfig(dry_run=False, backends=backend_config)
+    expected_backend_types = [AwsS3Backend]
+    with provide_BowserBackends(
+        watch_root=tmp_path, config=config, dry_run=False
+    ) as actual_backends:
+        actual_backend_types = [backend.__class__ for backend in actual_backends]
+    # TODO: is there a stronger assertion that can be made here without baking in too
+    #  many implementation details? Perhaps some custom hamcrest matchers.
+    assert_that(actual_backend_types, contains_inanyorder(*expected_backend_types))
+
+
+def test_provide_BowserBackends_dry_run_mode(tmp_path: Path):  # noqa: N802
+    backend_config = [
+        AwsS3BowserBackendConfig(
+            region="eu-west-1",  # exercise a region other than the default
+            access_key_id="testing",
+            secret_access_key="testing",  # nosec B106
+            buckets=[Bucket(name="test-bucket", key="")],
+        )
+    ]
+    config = BowserConfig(dry_run=True, backends=backend_config)
+    expected_backend_types = [AwsS3Backend]
+    with provide_BowserBackends(
+        watch_root=tmp_path, config=config, dry_run=True
+    ) as actual_backends:
+        actual_backend_types = [backend.__class__ for backend in actual_backends]
+    # TODO: is there a stronger assertion that can be made here without baking in too
+    #  many implementation details? Perhaps some custom hamcrest matchers.
+    assert_that(actual_backend_types, contains_inanyorder(*expected_backend_types))

--- a/tests/unit/config/data/bowser.toml
+++ b/tests/unit/config/data/bowser.toml
@@ -1,6 +1,4 @@
 [bowser]
-polling_interval = 311
-
 [[bowser.backends]]
 kind="AWS-S3"
 region="eu-west-1"


### PR DESCRIPTION
When regions other than the default `us-east-1` are specified, the `client.create_bucket` calls which are only performed in dry run mode (`dry_run = True`) fail with the error:

```text
botocore.exceptions.ClientError: An error occurred (IllegalLocationConstraintException) when calling the CreateBucket operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.
```

This pull request adds `{"LocationConstraint": config.region}` to the `client.create_bucket` calls in dry run mode and adds a test that reproduces this error in absence of the fix.