### PR TITLE
Switch to Boto3's Resource API

### DIFF
--- a/src/bowser/backends/di.py
+++ b/src/bowser/backends/di.py
@@ -60,8 +60,14 @@ def provide_S3Client(  # noqa: N802
             s3 = boto3.resource("s3", **kwargs)  # type: ignore[call-overload]
             for bucket in config.buckets:
                 s3bucket = s3.Bucket(bucket.name)
-                location = {"LocationConstraint": config.region}
-                s3bucket.create(CreateBucketConfiguration=location)
+                kwargs = {}
+                if config.region != "us-east-1":
+                    # turns out that us-east-1 is not a valid location constraint region,
+                    # so only pass this on if we're not working in us-east-1
+                    kwargs["CreateBucketConfiguration"] = {
+                        "LocationConstraint": config.region
+                    }
+                s3bucket.create(**kwargs)
             # this has to remain here, so we remain within the context of moto while the rest
             # of the program executes
             # moving this call outside of this `with` block means mocking by moto stops before

--- a/tests/unit/backends/test_di.py
+++ b/tests/unit/backends/test_di.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from hamcrest import assert_that, contains_inanyorder
 
 from bowser.backends.aws import AwsS3Backend
@@ -8,10 +9,11 @@ from bowser.config.backend.aws import AwsS3BowserBackendConfig, Bucket
 from bowser.config.base import BowserConfig
 
 
-def test_provide_BowserBackends(tmp_path: Path):  # noqa: N802
+@pytest.mark.parametrize("region", ["us-east-1", "eu-west-1", "ap-southeast-3"])
+def test_provide_BowserBackends(region: str, tmp_path: Path):  # noqa: N802
     backend_config = [
         AwsS3BowserBackendConfig(
-            region="eu-west-1",  # exercise a region other than the default
+            region=region,
             access_key_id="testing",
             secret_access_key="testing",  # nosec B106
             buckets=[Bucket(name="test-bucket", key="")],


### PR DESCRIPTION
Bowser only needs functions which are currently covered by the boto3 resource API, and it is a bit easier to work with since response data are marshaled to domain types and the API is more expressive.

This MR also fixes another bug with the `LocationConstraint` used in creating buckets with the moto client, which was discovered while testing the other changes. Apparently `us-east-1` is not allowed to be used as a location constraint with `create_bucket`, either because the type definition just doesn't include it or because it's the default region.