### PR TITLE
Add support for creating links in the AWS S3 Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ secret_access_key = "secret squirrel stuff"
 
 [[bowser.backends.buckets]]
 name = "a literal bucket"
-key = "some/root/key"
+prefix = "some/root/prefix"
 ```
 
 These select configuration fields in the root `bowser` table can be overridden with the highest
@@ -144,11 +144,11 @@ secret_access_key = "secret squirrel stuff"
 
 [[bowser.backends.buckets]]
 name = "test-bucket"
-key = "some/root/key"
+prefix = "some/root/prefix"
 
 [[bowser.backends.buckets]]
 name = "staging-bucket"
-key = ""
+prefix = ""
 
 [[bowser.backends]]
 kind = "AWS-S3"
@@ -158,7 +158,7 @@ secret_access_key = "secret squirrel stuff"
 
 [[bowser.backends.buckets]]
 name = "staging-bucket"
-key = ""
+prefix = ""
 ```
 
 The `region`, `access_key_id`, and `secret_access_key` fields are all required in order for the
@@ -169,8 +169,8 @@ Multiple `AWS-S3` backends must be configured if uploading to multiple regions i
 For each bucket the bucket `name` field needs to match the name of the bucket in the configured
 region.
 
-For each bucket the bucket `key` field is added as an additional prefix to the resulting
-object key before upload. In other words, you can use `key` to specify that content should go
+For each bucket the bucket `prefix` field is added as an additional prefix to the resulting
+object key before upload. In other words, you can use `prefix` to specify that content should go
 under a certain prefix in the target bucket.
 
 #### Implementation Details
@@ -201,8 +201,8 @@ under a certain prefix in the target bucket.
 
 then the resulting key for `test2/subtree/content.yml` will be `test2/subtree/content.yml` 
 assuming no `key` is specified in your backend bucket configuration. If your bucket definition 
-provides `key = "some/root/key` then the resulting key for `test2/subtree/content.yml` will be 
-`some/root/key/test2/subtree/content.yml`.
+provides `prefix = "some/root/prefix` then the resulting prefix for `test2/subtree/content.yml` will be 
+`some/root/prefix/test2/subtree/content.yml`.
 
 * The AWS S3 backend skips uploading any Bowser sentinel files like `.bowser.ready` or
   `.bowser.complete`.

--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -10,3 +10,7 @@ secret_access_key = "secret squirrel stuff"
 [[bowser.backends.buckets]]
 name = "a literal bucket"
 prefix = "some/root/prefix"
+
+[bowser.backends.buckets.link]
+target = {kind="RegexMatch", pattern='\d{8}T\d{6}'}
+name = "latest"

--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -9,4 +9,4 @@ secret_access_key = "secret squirrel stuff"
 
 [[bowser.backends.buckets]]
 name = "a literal bucket"
-key = "some/root/key"
+prefix = "some/root/prefix"

--- a/src/bowser/backends/aws.py
+++ b/src/bowser/backends/aws.py
@@ -62,8 +62,8 @@ class AwsS3Backend(BowserBackend):
             s3bucket = self._s3.Bucket(bucket.name)
             for path, meta in for_upload:
                 relative_path = path.relative_to(self.watch_root)
-                # lstrip to remove any unwanted leading "/" e.g. if `bucket.key` is empty
-                key = f"{bucket.key}/{relative_path!s}".lstrip("/")
+                # lstrip to remove any unwanted leading "/" e.g. if `bucket.prefix` is empty
+                key = f"{bucket.prefix}/{relative_path!s}".lstrip("/")
                 tags = _convert_metadata_to_s3_object_tags(meta)
                 LOGGER.info("Uploading %s to %s/%s", path, bucket.name, key)
                 s3bucket.upload_file(

--- a/src/bowser/config/backend/aws.py
+++ b/src/bowser/config/backend/aws.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import BaseModel, SecretStr
 
 from ...extensions.pydantic import Literally
+from ..link import Link
 from .base import BowserBackendConfig
 
 
@@ -17,6 +18,7 @@ class Bucket(BaseModel, frozen=True):
 
     If it is not empty, then content will be sync'd under the provided key.
     """
+    link: Link | None = None
 
 
 class AwsBowserBackendConfig(BowserBackendConfig, frozen=True):

--- a/src/bowser/config/backend/aws.py
+++ b/src/bowser/config/backend/aws.py
@@ -9,7 +9,7 @@ from .base import BowserBackendConfig
 class Bucket(BaseModel, frozen=True):
     name: str
     """The target bucket name."""
-    key: str = ""
+    prefix: str = ""
     """The root key content should go under.
 
     If, for example, this is empty then content will be sync'd directly to the top-level

--- a/src/bowser/config/link.py
+++ b/src/bowser/config/link.py
@@ -1,0 +1,94 @@
+from abc import ABC, abstractmethod
+from re import Pattern, sub
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from bowser.extensions.pydantic import Literally
+
+
+class LinkTargetMatcher(BaseModel, ABC, frozen=True):
+    kind: str
+    """A convenient discriminator and label for printing or log messages.
+
+    This should be overridden by subclasses.
+    """
+
+    @abstractmethod
+    def matches(self, value: str) -> bool:
+        """Determine if ``value`` is valid according to the rules of this matcher.
+
+        Actual match logic is dependent on the concrete subclass.
+        """
+        raise NotImplementedError()
+
+
+class RegexLinkTargetMatcher(LinkTargetMatcher, frozen=True):
+    """Uses ``pattern`` to determine if a string is a valid link target.
+
+    Notes:
+        Determining a match uses :py:func:`re.search`, rather than a strict match.
+    """
+
+    pattern: Pattern[str]
+    kind: Literal["RegexMatch"] = Literally("RegexMatch")
+
+    def matches(self, value: str) -> bool:
+        """Determine if ``value`` matches ``pattern`` using :py:func:`re.Pattern.search`."""
+        return bool(self.pattern.search(value))
+
+
+class LiteralLinkTargetMatcher(LinkTargetMatcher, frozen=True):
+    """Uses ``literal`` to determine if a string is a valid link target.
+
+    Notes:
+        This is done using string equality.
+    """
+
+    literal: str
+    kind: Literal["Literal"] = Literally("Literal")
+
+    def matches(self, value: str) -> bool:
+        """Determine if ``value`` matches ``literal`` through string equality."""
+        return value == self.literal
+
+
+LinkTargetMatcherT = LiteralLinkTargetMatcher | RegexLinkTargetMatcher
+
+
+class Link(BaseModel, frozen=True):
+    """Represents a symbolic-like link named ``name`` pointing to ``target``."""
+
+    target: LinkTargetMatcherT = Field(discriminator="kind")
+    """The link target."""
+    name: str
+    """The link name."""
+
+    def substitute(self, string: str) -> str:
+        """Return ``string`` with whatever matches ``target`` replaced by ``name``.
+
+        Examples:
+            >>> from bowser.config.link import LiteralLinkTargetMatcher, RegexLinkTargetMatcher
+            >>> link = Link(target=LiteralLinkTargetMatcher(literal="some/prefix"), name="latest")
+            >>> object_key = "some/prefix/20240311T123456/report.json"
+            >>> link_key = link.substitute(object_key)
+            >>> assert link_key == "latest/20240311T123456/report.json"
+            >>> link = Link(target=RegexLinkTargetMatcher(pattern="\\d{8}T\\d{6}"), name="latest")
+            >>> link_key = link.substitute(object_key)
+            >>> assert link_key == "some/prefix/latest/report.json"
+
+        ValueError: If nothing matches ``target``.
+        """
+        if not self.target.matches(string):
+            raise ValueError(f"'{string}' does not match link target.")
+        match self.target:
+            case LiteralLinkTargetMatcher():
+                substitution = sub(self.target.literal, self.name, string)
+            case RegexLinkTargetMatcher():
+                substitution = self.target.pattern.sub(self.name, string)
+            case _:
+                raise RuntimeError(
+                    "Exhaustive match on LinkTargetMatcherT filed to match."
+                    f"Unknown match type: '{type(self.target)}'"
+                )
+        return substitution

--- a/tests/unit/backends/test_aws.py
+++ b/tests/unit/backends/test_aws.py
@@ -97,10 +97,10 @@ def test_aws_bowser_backend(
     for bucket in fake_configuration.buckets:
         expected_keys = {
             # .metadata and .bowser.{ready,complete} files should be skipped
-            f"{bucket.key}/common/ancestors/app1/content.txt".lstrip("/"),
-            f"{bucket.key}/common/ancestors/app2/subtree/content.json".lstrip("/"),
-            f"{bucket.key}/common/ancestors/app2/subtree/content.txt".lstrip("/"),
-            f"{bucket.key}/common/ancestors/app3/report.yml".lstrip("/"),
+            f"{bucket.prefix}/common/ancestors/app1/content.txt".lstrip("/"),
+            f"{bucket.prefix}/common/ancestors/app2/subtree/content.json".lstrip("/"),
+            f"{bucket.prefix}/common/ancestors/app2/subtree/content.txt".lstrip("/"),
+            f"{bucket.prefix}/common/ancestors/app3/report.yml".lstrip("/"),
         }
         s3bucket = fake_s3_client.Bucket(bucket.name)
         objects = s3bucket.objects.all()


### PR DESCRIPTION
Since S3 doesn't natively have links (or directories for that matter) a link is just a copy of a particular prefix. For example, for this configuration:

```toml
[bowser]
dry_run = true

[[bowser.backends]]
kind = "AWS-S3"
region = "eu-west-1"
access_key_id = "access key"
secret_access_key = "secret squirrel stuff"

[[bowser.backends.buckets]]
name = "a literal bucket"
prefix = ""

[bowser.backends.buckets.link]
target = {kind="RegexMatch", pattern='\d{8}T\d{6}'}
name = "latest"
```

And this directory structure:

```text
/tmp/blind-rage/
├── .bowser.complete
└── level0
    └── level1
        └── level2
            └── 20240311T121714
                ├── catalyzing-shields
                │   ├── .bowser.ready
                │   └── report.json
                ├── fleeting-expertise
                │   ├── .bowser.ready
                │   └── report.json
                ├── natural-talent
                │   ├── .bowser.ready
                │   └── report.txt
                └── overextended
                    ├── .bowser.ready
                    └── report.txt
```

then when `overextended` is marked ready for upload (i.e. the `.bowser.ready` sentinel file is created) the following happens:

1. The prefix `level0/level1/level2/20240311T121714/overextended` is transformed to a "link" named `level0/level1/level2/latest/overextended`.
2. Objects in the bucket `a literal bucket` with the prefix `level0/level1/level2/latest/overextended` are deleted, if there are any.
3. Files under the path `level0/level1/level2/20240311T121714/overextended` are uploaded to the bucket `a literal bucket` with prefixes `level0/level1/level2/20240311T121714/overextended` and `level0/level1/level2/latest/overextended`.