### PR TITLE
Bug fix: Use obj.get("Deleted", []) on response from s3.Bucket.delete

### DIFF
--- a/src/bowser/backends/aws.py
+++ b/src/bowser/backends/aws.py
@@ -76,7 +76,7 @@ class AwsS3Backend(BowserBackend):
                     )
                     objects = s3bucket.objects.filter(Prefix=link_prefix)
                     response = objects.delete()
-                    deleted = sum(len(obj["Deleted"]) for obj in response)
+                    deleted = sum(len(obj.get("Deleted", [])) for obj in response)
                     LOGGER.info(
                         "Removed %d objects from link prefix %s...",
                         deleted,


### PR DESCRIPTION
It appears the response from BucketObjectsCollection#delete can sometimes return a non-empty array of objects that don't conform to the advertised type information from `mypy_boto_s3`. If the array is non-empty, it should only contain objects of type `DeleteObjectsOutputTypeDef`, which advertises a required field called "Deleted". 

However, it was observed in practice that in cases where no objects are deleted the response is coming back both non-empty, and containing items without this required field causing errors at runtime.

The fix here is to use `.get("Deleted", [])`, but based on all the documentation I could find this case shouldn't happen. The root cause is still under investigation.