### PR TITLE
Feature: Bowser Abort

### DIFF
--- a/src/bowser/commands/watch/_preempt.py
+++ b/src/bowser/commands/watch/_preempt.py
@@ -1,0 +1,42 @@
+import logging
+from pathlib import Path
+
+from reactivex import Observable
+from reactivex.abc import DisposableBase, ObserverBase, SchedulerBase
+from watchdog.events import FileCreatedEvent
+
+from bowser.extensions.rx import ObservableTransformer
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PreemptObservable(ObservableTransformer[FileCreatedEvent]):
+    def __init__(self, sentinel: Path | None = None) -> None:
+        self._sentinel = sentinel or Path(".bowser.abort")
+
+    def __call__(
+        self, upstream: Observable[FileCreatedEvent]
+    ) -> Observable[FileCreatedEvent]:
+        def subscribe(
+            observer: ObserverBase[FileCreatedEvent],
+            scheduler: SchedulerBase | None = None,
+        ) -> DisposableBase:
+
+            def on_next(event: FileCreatedEvent) -> None:
+                src = event.src_path
+                if isinstance(src, bytes):
+                    src = src.decode("utf-8")
+                as_path = Path(src)
+                if as_path == self._sentinel:
+                    observer.on_completed()
+                else:
+                    observer.on_next(event)
+
+            return upstream.subscribe(
+                on_next=on_next,
+                on_error=observer.on_error,
+                on_completed=observer.on_completed,
+                scheduler=scheduler,
+            )
+
+        return Observable(subscribe)

--- a/src/bowser/commands/watch/_strategy.py
+++ b/src/bowser/commands/watch/_strategy.py
@@ -65,7 +65,10 @@ class SentinelWatchStrategy(WatchStrategy):
                     observer.on_completed()
 
             return upstream.subscribe(
-                on_next, observer.on_error, observer.on_completed, scheduler=scheduler
+                on_next=on_next,
+                on_error=observer.on_error,
+                on_completed=observer.on_completed,
+                scheduler=scheduler,
             )
 
         return Observable(subscribe)


### PR DESCRIPTION
Add support for telling Bowser to abort with a new sentinel file `.bowser.abort` in the root watch directory. This is achieved by adding a `PreemptObservable` in to the stream, which completes itself and all downstream observers if this sentinel file is encountered, preempting the `--strategy` chosen by the user.