### PR TITLE
cli: Add -p/--preempt-sentinel to customize the abort sentinel

### DIFF
--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -86,6 +86,16 @@ def _validate_count(_: click.Context, __: str, value: int | None) -> int | None:
         "Must be >= 1."
     ),
 )
+@click.option(
+    "-p",
+    "--preempt-sentinel",
+    type=Path,
+    default=None,
+    help=(
+        "If present, this particular sentinel file will be used as a signal to abort,"
+        "preempting whatever is passed for --strategy. Default: DIR/.bowser.abort"
+    ),
+)
 @click.argument("root", metavar="DIR", type=click.Path(path_type=Path, exists=True))
 @pass_config
 def watch(
@@ -93,6 +103,7 @@ def watch(
     dry_run: bool,  # noqa: FBT001
     strategy: WatchType,
     count: int | None,
+    preempt_sentinel: Path | None,
     root: Path,
 ) -> None:
     """Watch DIR (recursively) and upload trees marked as ready.
@@ -130,6 +141,7 @@ def watch(
             root,
             backends=backends,
             transform=watch_strategy,
+            preempt_sentinel=preempt_sentinel or (root / ".bowser.abort"),
         )
 
     LOGGER.info("Exiting.")

--- a/src/bowser/commands/watch/_impl.py
+++ b/src/bowser/commands/watch/_impl.py
@@ -58,6 +58,7 @@ def execute(
     root: Path,
     backends: Collection[BowserBackend],
     transform: WatchStrategy,
+    preempt_sentinel: Path,
 ) -> None:
     cpus = os.cpu_count() or 1
     workers = max(cpus, 1)
@@ -70,7 +71,7 @@ def execute(
     origin.pipe(
         ops.subscribe_on(scheduler),
         ops.observe_on(scheduler),
-        PreemptObservable(root / ".bowser.abort"),
+        PreemptObservable(sentinel=preempt_sentinel),
         transform,
     ).subscribe(terminus)
 

--- a/src/bowser/commands/watch/_preempt.py
+++ b/src/bowser/commands/watch/_preempt.py
@@ -7,7 +7,7 @@ from watchdog.events import FileCreatedEvent
 
 from bowser.extensions.rx import ObservableTransformer
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("bowser")
 
 
 class PreemptObservable(ObservableTransformer[FileCreatedEvent]):
@@ -28,6 +28,7 @@ class PreemptObservable(ObservableTransformer[FileCreatedEvent]):
                     src = src.decode("utf-8")
                 as_path = Path(src)
                 if as_path == self._sentinel:
+                    LOGGER.info("Abort signal detected")
                     observer.on_completed()
                 else:
                     observer.on_next(event)


### PR DESCRIPTION
This allows the caller to specify where the abort sentinel can come from without having to figure out what path Bowser was passed to DIR and match that.