### PR TITLE
Bug Fix: Ensure atomicity in uploads by clobbering the destination key before upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ py_version = 311
 exclude_dirs = [".venv", ".*_cache", ".pdm-build", "docs", "htmlcov", ".gitlab"]
 skips = ["B404"]
 
+# B101: Test for use of assert
+[tool.bandit.assert_used]
+skips = ["*_test.py", "*test_*.py"]
+
 [tool.mypy]
 python_version = "3.11"
 exclude = '\.venv\.*'

--- a/src/bowser/backends/aws.py
+++ b/src/bowser/backends/aws.py
@@ -2,18 +2,19 @@ import logging
 import os
 from collections.abc import Mapping, MutableSequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from urllib.parse import urlencode
+
+from ..result import Result
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
 
-from ..config.backend.aws import AwsS3BowserBackendConfig
+from ..config.backend.aws import AwsS3BowserBackendConfig, Bucket
 from ._common import get_metadata_for_file
 from .base import BowserBackend
 
 LOGGER = logging.getLogger("bowser")
-
 
 AWS_TAG_MAXIMUM = 10
 
@@ -46,49 +47,69 @@ class AwsS3Backend(BowserBackend):
         not_metadata = not filename.endswith(".metadata")
         return not_bowser and not_metadata
 
+    def _clear_prefix(self, bucket: Bucket, prefix: str) -> Result[int]:
+        LOGGER.info(
+            "Clearing prefix %s...",
+            prefix,
+        )
+        s3bucket = self._s3.Bucket(bucket.name)
+        objects = s3bucket.objects.filter(Prefix=prefix)
+        try:
+            response = objects.delete()
+        except Exception as e:
+            return Result[int].failure(e)
+
+        deleted = sum(len(obj.get("Deleted", [])) for obj in response)
+        return Result[int].success(deleted)
+
+    def clear_prefix(self, bucket: Bucket, prefix: str) -> int:
+        result = self._clear_prefix(bucket, prefix)
+        if (exc := result.exception_or_none()) is not None:
+            raise exc
+
+        return cast(int, result.get_or_none())
+
     def upload(self, source: Path) -> None:
         """Upload files in the tree rooted at ``source`` to AWS S3.
 
         The name of ``source`` likewise becomes the root of the resulting object's key
         on S3.
         """
-        for_upload: MutableSequence[_FileMetadataPair] = []
-        for root, _, files in os.walk(source):
-            for file in filter(self._filter, files):
-                local = Path(root, file)
-                metadata: Mapping[str, Any] = get_metadata_for_file(local)
-                for_upload.append(_FileMetadataPair(local, metadata))
-
+        source_as_relative_path = source.relative_to(self.watch_root)
         for bucket in self._config.buckets:
-            if bucket.link is not None:
-                # first, for each bucket ensure any links are deleted before possibly being
-                # re-created
-                # assumes that links are somewhere on the path between the watch root and the tree
-                # rooted at `source`, which is the parent for all objects being uploaded
-                relative_path = source.relative_to(self.watch_root)
-                tree_prefix = f"{bucket.prefix}/{relative_path!s}".lstrip("/")
-                if bucket.link.target.matches(tree_prefix):
-                    link_prefix = bucket.link.substitute(tree_prefix)
-                    s3bucket = self._s3.Bucket(bucket.name)
-                    LOGGER.info(
-                        "Clearing link prefix %s before uploading any objects...",
-                        link_prefix,
-                    )
-                    objects = s3bucket.objects.filter(Prefix=link_prefix)
-                    response = objects.delete()
-                    deleted = sum(len(obj.get("Deleted", [])) for obj in response)
-                    LOGGER.info(
-                        "Removed %d objects from link prefix %s...",
-                        deleted,
-                        link_prefix,
-                    )
+            source_prefix = bucket / source_as_relative_path
+            # ensure any links are deleted before possibly being re-created
+            # assumes that links are somewhere on the path between the watch root and the tree
+            # rooted at `source`, which is the parent for all objects being uploaded
+            if bucket.link is not None and bucket.link.target.matches(source_prefix):
+                link_prefix = bucket.link.substitute(source_prefix)
+                deleted = self.clear_prefix(bucket, link_prefix)
+                LOGGER.info(
+                    "Removed %d objects from link prefix %s...",
+                    deleted,
+                    link_prefix,
+                )
 
-        for bucket in self._config.buckets:
+            # clear destination to make upload idempotent on retries
+            deleted = self.clear_prefix(bucket, source_prefix)
+            LOGGER.info(
+                "Removed %d objects from prefix %s...",
+                deleted,
+                source_prefix,
+            )
+
+            # resolve files for upload
+            for_upload: MutableSequence[_FileMetadataPair] = []
+            for root, _, files in os.walk(source):
+                for file in filter(self._filter, files):
+                    local = Path(root, file)
+                    metadata: Mapping[str, Any] = get_metadata_for_file(local)
+                    for_upload.append(_FileMetadataPair(local, metadata))
+
             s3bucket = self._s3.Bucket(bucket.name)
             for path, meta in for_upload:
-                relative_path = path.relative_to(self.watch_root)
-                # lstrip to remove any unwanted leading "/" e.g. if `bucket.prefix` is empty
-                key = f"{bucket.prefix}/{relative_path!s}".lstrip("/")
+                as_relative_path = path.relative_to(self.watch_root)
+                key = bucket / as_relative_path
                 tags = _convert_metadata_to_s3_object_tags(meta)
                 LOGGER.info("Uploading %s to %s/%s", path, bucket.name, key)
                 s3bucket.upload_file(

--- a/src/bowser/config/backend/aws.py
+++ b/src/bowser/config/backend/aws.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, SecretStr
@@ -19,6 +20,12 @@ class Bucket(BaseModel, frozen=True):
     If it is not empty, then content will be sync'd under the provided key.
     """
     link: Link | None = None
+
+    def __truediv__(self, other: Path | str) -> str:
+        return self.join_prefix(other)
+
+    def join_prefix(self, prefix: Path | str) -> str:
+        return f"{self.prefix}/{prefix!s}".lstrip("/")
 
 
 class AwsBowserBackendConfig(BowserBackendConfig, frozen=True):

--- a/src/bowser/config/link.py
+++ b/src/bowser/config/link.py
@@ -77,7 +77,8 @@ class Link(BaseModel, frozen=True):
             >>> link_key = link.substitute(object_key)
             >>> assert link_key == "some/prefix/latest/report.json"
 
-        ValueError: If nothing matches ``target``.
+        Raises:
+            ValueError: If nothing matches ``target``.
         """
         if not self.target.matches(string):
             raise ValueError(f"'{string}' does not match link target.")
@@ -88,7 +89,7 @@ class Link(BaseModel, frozen=True):
                 substitution = self.target.pattern.sub(self.name, string)
             case _:
                 raise RuntimeError(
-                    "Exhaustive match on LinkTargetMatcherT filed to match."
+                    "Exhaustive match on LinkTargetMatcherT failed to match."
                     f"Unknown match type: '{type(self.target)}'"
                 )
         return substitution

--- a/src/bowser/result.py
+++ b/src/bowser/result.py
@@ -1,0 +1,47 @@
+from abc import ABC
+from typing import Any, Generic, Never, TypeVar, cast
+
+from attrs import frozen
+
+T = TypeVar("T")
+Out = TypeVar("Out", covariant=True)
+Nothing = Never
+
+
+class Result(ABC, Generic[Out]):
+    def __init__(self, value: Any | None) -> None:
+        """Do not call the constructor directly from client code.
+
+        Instead, use the factory methods Result.success and Result.failure.
+        """
+        self._value = value
+
+    @frozen
+    class _Failure:
+        exc: Exception
+
+    @classmethod
+    def success(cls, value: T) -> "Result[T]":
+        return Result(value)
+
+    @classmethod
+    def failure(cls, exc: Exception) -> "Result[Out]":
+        return Result(Result._Failure(exc))
+
+    @property
+    def is_success(self) -> bool:
+        return not isinstance(self._value, self._Failure)
+
+    @property
+    def is_failure(self) -> bool:
+        return isinstance(self._value, self._Failure)
+
+    def get_or_none(self) -> Out | None:
+        return cast(Out, self._value) if self.is_success else None
+
+    def exception_or_none(self) -> Exception | None:
+        # Ignore: mypy union-attr
+        # Reason: self.is_failure returns True implies isinstance(self._value, Result._Failure)
+        #   which has the attribute exc. I could inline the isinstance call here to
+        #   help mypy, but why not use the property that's made for this.
+        return self._value.exc if self.is_failure else None  # type: ignore[union-attr]

--- a/tests/unit/test_result.py
+++ b/tests/unit/test_result.py
@@ -1,0 +1,20 @@
+from bowser.result import Result
+
+
+def test_success_construction() -> None:
+    success = Result[str].success("Success")
+    assert success.is_success
+    assert not success.is_failure
+    assert success.get_or_none() is not None
+    assert success.get_or_none() == "Success"
+    assert success.exception_or_none() is None
+
+
+def test_failure_construction() -> None:
+    err = RuntimeError("Failure")
+    failure = Result[str].failure(err)
+    assert failure.is_failure
+    assert not failure.is_success
+    assert failure.get_or_none() is None
+    assert failure.exception_or_none() is not None
+    assert failure.exception_or_none() is err


### PR DESCRIPTION
This helps ensure atomicity of data that's warehoused because any temporally unique objects like files with timestamps or UUIDs in the name will not persist in the warehouse if the main application finishes and is retried.